### PR TITLE
Add support for SMILES and InChI formats

### DIFF
--- a/ChemLook.xcodeproj/project.xcworkspace/xcshareddata/ChemLook.xccheckout
+++ b/ChemLook.xcodeproj/project.xcworkspace/xcshareddata/ChemLook.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>83FC1855-6FA3-4333-8E60-703D1AABCBD3</string>
+	<string>7635E305-C042-4272-978D-EEBB1CD9AACD</string>
 	<key>IDESourceControlProjectName</key>
 	<string>ChemLook</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>25562E99-CE41-4EBF-9CC4-DF355D4D599F</key>
-		<string>ssh://github.com/mcs07/ChemLook.git</string>
+		<key>CBE6A3A5-4186-4F24-ACE3-0930EC33DC2A</key>
+		<string>https://github.com/ghutchis/ChemLook.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>ChemLook.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>25562E99-CE41-4EBF-9CC4-DF355D4D599F</key>
+		<key>CBE6A3A5-4186-4F24-ACE3-0930EC33DC2A</key>
 		<string>../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>ssh://github.com/mcs07/ChemLook.git</string>
+	<string>https://github.com/ghutchis/ChemLook.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>25562E99-CE41-4EBF-9CC4-DF355D4D599F</string>
+	<string>CBE6A3A5-4186-4F24-ACE3-0930EC33DC2A</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>25562E99-CE41-4EBF-9CC4-DF355D4D599F</string>
+			<string>CBE6A3A5-4186-4F24-ACE3-0930EC33DC2A</string>
 			<key>IDESourceControlWCCName</key>
 			<string>ChemLook</string>
 		</dict>

--- a/Common.m
+++ b/Common.m
@@ -34,9 +34,13 @@ NSString *RunTask(NSString *cmd, int *status) {
     return output;
 }
 
-NSString *MolDataFromOpenBabel(NSURL *url) {
+NSString *MolDataFromOpenBabel(NSURL *url, bool gen2d) {
     int status;
-    NSString *cmd = [NSString stringWithFormat:@"'/usr/local/bin/obabel' '%@' -ocdjson -l 20", [[url absoluteURL] path]];
+    NSString *options = @"-ocdjson -l 20";
+    if (gen2d) {
+        options = [options stringByAppendingString:@" --gen2d"];
+    }
+    NSString *cmd = [NSString stringWithFormat:@"'/usr/local/bin/obabel' '%@' %@", [[url absoluteURL] path], options];
     NSString *output = RunTask(cmd, &status);
     if (status != 0) {
         NSLog(@"Error running command: %@", cmd);
@@ -62,10 +66,11 @@ NSString *EscapeStringForJavascript(NSString *string) {
 }
 
 NSString *PreviewURL(CFBundleRef bundle, NSURL *url, NSError *error, bool thumbnail) {
-    
+
     // Use Open Babel to generate ChemDoodle JSON from file contents
-    NSString *cdjson = MolDataFromOpenBabel(url);
     NSString *extension = [[[url path] pathExtension] lowercaseString];
+    bool gen2d = [@[@"smiles", @"smi", @"inchi"] containsObject:extension];
+    NSString *cdjson = MolDataFromOpenBabel(url, gen2d);
 
     // Read the raw file contents if Open Babel failed or if a cif (for unit cell info)
     NSString *raw = nil;

--- a/Info.plist
+++ b/Info.plist
@@ -34,6 +34,8 @@
 				<string>de.gwdg.gwdg.shelx.ins</string>
 				<string>de.gwdg.gwdg.shelx.res</string>
 				<string>com.hyper.hin</string>
+				<string>com.daylight.smiles</string>
+				<string>org.iupac.inchi</string>
 			</array>
 		</dict>
 	</array>
@@ -549,6 +551,50 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>chemical/x-hin</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Daylight SMILES</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.daylight.smiles</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>smiles</string>
+					<string>smi</string>
+					<string>can</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>chemical/x-daylight-smiles</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>IUPAC InChI</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.iupac.inchi</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>inchi</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>chemical/x-inchi</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Use the Open Babel `gen2d` option to generate 2D coordinates for files containing SMILES and InChI formats.
